### PR TITLE
Enable SHA2_256_HMAC and SHA2_512_HMAC in dropbear

### DIFF
--- a/package/network/services/dropbear/patches/120-openwrt_options.patch
+++ b/package/network/services/dropbear/patches/120-openwrt_options.patch
@@ -29,15 +29,19 @@
  
  /* Enable "Counter Mode" for ciphers. This is more secure than normal
   * CBC mode against certain attacks. This adds around 1kB to binary 
-@@ -122,7 +122,7 @@ much traffic. */
+@@ -122,9 +122,9 @@ much traffic. */
   * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
   * which are not the standard form. */
  #define DROPBEAR_SHA1_HMAC
 -#define DROPBEAR_SHA1_96_HMAC
+-/*#define DROPBEAR_SHA2_256_HMAC*/
+-/*#define DROPBEAR_SHA2_512_HMAC*/
 +/*#define DROPBEAR_SHA1_96_HMAC*/
- /*#define DROPBEAR_SHA2_256_HMAC*/
- /*#define DROPBEAR_SHA2_512_HMAC*/
++#define DROPBEAR_SHA2_256_HMAC
++#define DROPBEAR_SHA2_512_HMAC
  #define DROPBEAR_MD5_HMAC
+
+ /* You can also disable integrity. Don't bother disabling this if you're
 @@ -175,7 +175,7 @@ much traffic. */
  
  /* Whether to print the message of the day (MOTD). This doesn't add much code


### PR DESCRIPTION
Dropbear in cero does not support SHA2 HMACs.

root@cerowrt:/etc# ssh -m help
ssh: Available MACs:
hmac-sha1-96,hmac-sha1,hmac-md5

The objective of the patch is to enable SHA2 HMACs that exist since 2013.56.
The purpose of the patch is to allow ssh communication with hosts that do not support SHA1 or MD5 MACs as suggested by bettercrypto.org folks.

Please review.
Maciej
