### PR TITLE
Add 'sleep 10' to allow DNS resolvers and dnsmasq to return before updating 6in4 tunnel

### DIFF
--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -69,6 +69,9 @@ proto_6in4_setup() {
 		local try=0
 		local max=3
 
+		# give time for dns resolvers and dnsmasq to reinitialize
+		sleep 10
+		
 		while [ $((++try)) -le $max ]; do
 			( exec wget -qO/dev/null "$url" 2>/dev/null ) &
 			local pid=$!


### PR DESCRIPTION
See https://forum.openwrt.org/viewtopic.php?pid=255401#p255401 for details